### PR TITLE
set back env PORT to 3000

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "test": "nodemon server.js",
-    "start": "env PORT=80 node server.js"
+    "start": "env PORT=3000 node server.js"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
for security concern,
if someone want to use http://<domain>/ to connect to service directly
just use 301 redirect feature provided by web server
or maybe we can try reverse proxy?